### PR TITLE
Fix Makefile for local iteration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,6 @@ local_run: vendorize
 	bk local run .buildkite/local-pipeline.yml
 
 vendorize:
+	rm -rf .buildkite/plugins/metahook
 	mkdir -p .buildkite/plugins/metahook
-	cp -rf hooks python plugin.yml .buildkite/plugins/metahook/
+	cp -rf hooks plugin.yml .buildkite/plugins/metahook/


### PR DESCRIPTION
* make sure to completely replace the vendored plugin. Avoids issues when modifying the hooks in `local-pipeline.yaml`.
* python isn't a directory anymore
